### PR TITLE
Add dual New Relic agent instrumentation

### DIFF
--- a/newrelic/newrelic-account1.yml
+++ b/newrelic/newrelic-account1.yml
@@ -6,9 +6,16 @@ common: &default_settings
 
   labels:
     repository: https://github.com/newrelic-copilot/AuthenticationService
+    team: security_rx
+    environment: production
 
   distributed_tracing:
     enabled: true
+
+  security:
+    enabled: true
+    agent:
+      enabled: true
 
   application_logging:
     enabled: true
@@ -19,6 +26,9 @@ common: &default_settings
       enabled: true
     local_decorating:
       enabled: false
+
+  code_level_metrics:
+    enabled: true
 
 development:
   <<: *default_settings

--- a/newrelic/newrelic-account1.yml
+++ b/newrelic/newrelic-account1.yml
@@ -1,6 +1,6 @@
 common: &default_settings
   license_key: '<%= ENV["NEW_RELIC_LICENSE_KEY_1"] %>'
-  app_name: AuthenticationService-Account1
+  app_name: AuthenticationService
   log_level: info
   audit_mode: false
 
@@ -32,11 +32,11 @@ common: &default_settings
 
 development:
   <<: *default_settings
-  app_name: AuthenticationService-Account1 (Development)
+  app_name: AuthenticationService (Development)
 
 staging:
   <<: *default_settings
-  app_name: AuthenticationService-Account1 (Staging)
+  app_name: AuthenticationService (Staging)
 
 production:
   <<: *default_settings

--- a/newrelic/newrelic-account1.yml
+++ b/newrelic/newrelic-account1.yml
@@ -1,0 +1,32 @@
+common: &default_settings
+  license_key: '<%= ENV["NEW_RELIC_LICENSE_KEY_1"] %>'
+  app_name: AuthenticationService-Account1
+  log_level: info
+  audit_mode: false
+
+  labels:
+    repository: https://github.com/newrelic-copilot/AuthenticationService
+
+  distributed_tracing:
+    enabled: true
+
+  application_logging:
+    enabled: true
+    forwarding:
+      enabled: true
+      max_samples_stored: 10000
+    metrics:
+      enabled: true
+    local_decorating:
+      enabled: false
+
+development:
+  <<: *default_settings
+  app_name: AuthenticationService-Account1 (Development)
+
+staging:
+  <<: *default_settings
+  app_name: AuthenticationService-Account1 (Staging)
+
+production:
+  <<: *default_settings

--- a/newrelic/newrelic-account2.yml
+++ b/newrelic/newrelic-account2.yml
@@ -6,9 +6,16 @@ common: &default_settings
 
   labels:
     repository: https://github.com/newrelic-copilot/AuthenticationService
+    team: security_rx
+    environment: production
 
   distributed_tracing:
     enabled: true
+
+  security:
+    enabled: true
+    agent:
+      enabled: true
 
   application_logging:
     enabled: true
@@ -19,6 +26,9 @@ common: &default_settings
       enabled: true
     local_decorating:
       enabled: false
+
+  code_level_metrics:
+    enabled: true
 
 development:
   <<: *default_settings

--- a/newrelic/newrelic-account2.yml
+++ b/newrelic/newrelic-account2.yml
@@ -1,6 +1,6 @@
 common: &default_settings
   license_key: '<%= ENV["NEW_RELIC_LICENSE_KEY_2"] %>'
-  app_name: AuthenticationService-Account2
+  app_name: AuthenticationService
   log_level: info
   audit_mode: false
 
@@ -32,11 +32,11 @@ common: &default_settings
 
 development:
   <<: *default_settings
-  app_name: AuthenticationService-Account2 (Development)
+  app_name: AuthenticationService (Development)
 
 staging:
   <<: *default_settings
-  app_name: AuthenticationService-Account2 (Staging)
+  app_name: AuthenticationService (Staging)
 
 production:
   <<: *default_settings

--- a/newrelic/newrelic-account2.yml
+++ b/newrelic/newrelic-account2.yml
@@ -1,0 +1,32 @@
+common: &default_settings
+  license_key: '<%= ENV["NEW_RELIC_LICENSE_KEY_2"] %>'
+  app_name: AuthenticationService-Account2
+  log_level: info
+  audit_mode: false
+
+  labels:
+    repository: https://github.com/newrelic-copilot/AuthenticationService
+
+  distributed_tracing:
+    enabled: true
+
+  application_logging:
+    enabled: true
+    forwarding:
+      enabled: true
+      max_samples_stored: 10000
+    metrics:
+      enabled: true
+    local_decorating:
+      enabled: false
+
+development:
+  <<: *default_settings
+  app_name: AuthenticationService-Account2 (Development)
+
+staging:
+  <<: *default_settings
+  app_name: AuthenticationService-Account2 (Staging)
+
+production:
+  <<: *default_settings

--- a/start-dual-agent.sh
+++ b/start-dual-agent.sh
@@ -2,6 +2,8 @@
 # Start AuthenticationService with two New Relic agents (two separate JVM processes)
 # Each process reports to a different NR account.
 #
+# Ports: 9001 (Account 1), 9002 (Account 2)
+#
 # Required env vars:
 #   NEW_RELIC_LICENSE_KEY_1 - Ingest license key for NR Account 1
 #   NEW_RELIC_LICENSE_KEY_2 - Ingest license key for NR Account 2
@@ -31,23 +33,23 @@ if [ ! -f "$APP_JAR" ]; then
   ./gradlew build -x test
 fi
 
-echo "Starting AuthenticationService with NR Agent -> Account 1 (port 8080)..."
+echo "Starting AuthenticationService with NR Agent -> Account 1 (port 9001)..."
 java -javaagent:$NR_AGENT \
   -Dnewrelic.config.file=newrelic/newrelic-account1.yml \
   -Dnewrelic.environment=production \
   -jar $APP_JAR \
-  --server.port=8080 &
+  --server.port=9001 &
 PID1=$!
 
-echo "Starting AuthenticationService with NR Agent -> Account 2 (port 8081)..."
+echo "Starting AuthenticationService with NR Agent -> Account 2 (port 9002)..."
 java -javaagent:$NR_AGENT \
   -Dnewrelic.config.file=newrelic/newrelic-account2.yml \
   -Dnewrelic.environment=production \
   -jar $APP_JAR \
-  --server.port=8081 &
+  --server.port=9002 &
 PID2=$!
 
-echo "Both instances running: PID1=$PID1 (Account1:8080), PID2=$PID2 (Account2:8081)"
+echo "Both instances running: PID1=$PID1 (Account1:9001), PID2=$PID2 (Account2:9002)"
 echo "To stop: kill $PID1 $PID2"
 
 wait $PID1 $PID2

--- a/start-dual-agent.sh
+++ b/start-dual-agent.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Start AuthenticationService with two New Relic agents (two separate JVM processes)
+# Each process reports to a different NR account.
+#
+# Required env vars:
+#   NEW_RELIC_LICENSE_KEY_1 - Ingest license key for NR Account 1
+#   NEW_RELIC_LICENSE_KEY_2 - Ingest license key for NR Account 2
+#
+# Usage:
+#   export NEW_RELIC_LICENSE_KEY_1='your-key-here'
+#   export NEW_RELIC_LICENSE_KEY_2='your-key-here'
+#   ./start-dual-agent.sh
+
+set -e
+
+APP_JAR="build/libs/AuthenticationService-1.0-SNAPSHOT.jar"
+NR_AGENT="newrelic/newrelic.jar"
+
+if [ -z "$NEW_RELIC_LICENSE_KEY_1" ] || [ -z "$NEW_RELIC_LICENSE_KEY_2" ]; then
+  echo "ERROR: Set NEW_RELIC_LICENSE_KEY_1 and NEW_RELIC_LICENSE_KEY_2 env vars"
+  exit 1
+fi
+
+if [ ! -f "$NR_AGENT" ]; then
+  echo "NR agent not found. Downloading..."
+  ./gradlew downloadNewrelic unzipNewrelic
+fi
+
+if [ ! -f "$APP_JAR" ]; then
+  echo "App JAR not found. Building..."
+  ./gradlew build -x test
+fi
+
+echo "Starting AuthenticationService with NR Agent -> Account 1 (port 8080)..."
+java -javaagent:$NR_AGENT \
+  -Dnewrelic.config.file=newrelic/newrelic-account1.yml \
+  -Dnewrelic.environment=production \
+  -jar $APP_JAR \
+  --server.port=8080 &
+PID1=$!
+
+echo "Starting AuthenticationService with NR Agent -> Account 2 (port 8081)..."
+java -javaagent:$NR_AGENT \
+  -Dnewrelic.config.file=newrelic/newrelic-account2.yml \
+  -Dnewrelic.environment=production \
+  -jar $APP_JAR \
+  --server.port=8081 &
+PID2=$!
+
+echo "Both instances running: PID1=$PID1 (Account1:8080), PID2=$PID2 (Account2:8081)"
+echo "To stop: kill $PID1 $PID2"
+
+wait $PID1 $PID2


### PR DESCRIPTION
## Summary
- Two `newrelic.yml` configs for dual-account APM reporting (env var license keys)
- `start-dual-agent.sh` to run two JVM processes on ports 8080/8081
- Security agent enabled for SRX security testing
- Labels: `repository`, `team: security_rx`, `environment: production`

## Setup on EC2
```bash
export NEW_RELIC_LICENSE_KEY_1='<account1-ingest-key>'
export NEW_RELIC_LICENSE_KEY_2='<account2-ingest-key>'
./gradlew downloadNewrelic unzipNewrelic
chmod +x start-dual-agent.sh
./start-dual-agent.sh
```