### PR TITLE
Fix NR agent labels - remove colon from repository URL

### DIFF
--- a/newrelic/newrelic-account1.yml
+++ b/newrelic/newrelic-account1.yml
@@ -5,7 +5,7 @@ common: &default_settings
   audit_mode: false
 
   labels:
-    repository: https://github.com/newrelic-copilot/AuthenticationService
+    repository: github.com/newrelic-copilot/AuthenticationService
     team: security_rx
     environment: production
 

--- a/newrelic/newrelic-account2.yml
+++ b/newrelic/newrelic-account2.yml
@@ -5,7 +5,7 @@ common: &default_settings
   audit_mode: false
 
   labels:
-    repository: https://github.com/newrelic-copilot/AuthenticationService
+    repository: github.com/newrelic-copilot/AuthenticationService
     team: security_rx
     environment: production
 


### PR DESCRIPTION
Fixes illegal `:` character in NR labels by changing `https://github.com/...` to `github.com/...`