### PR TITLE
Convert to Spring Boot for NR agent vulnerability reporting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,8 @@ import org.gradle.wrapper.Download
 
 plugins {
     id("java")
+    id("org.springframework.boot") version "2.5.10"
+    id("io.spring.dependency-management") version "1.0.11.RELEASE"
     id("de.undercouch.download") version "5.3.0"
 }
 
@@ -16,7 +18,7 @@ tasks.register("downloadNewrelic") {
     doLast {
             val newrelicDir = file("newrelic")
             if (!newrelicDir.exists()) {
-                newrelicDir.mkdirs() // Create the directory if it doesn't exist
+                newrelicDir.mkdirs()
             }
         ant.invokeMethod("get", mapOf(
             "src" to "https://download.newrelic.com/newrelic/java-agent/newrelic-agent/current/newrelic-java.zip",
@@ -35,30 +37,23 @@ dependencies {
     implementation ("org.apache.commons:commons-lang3:3.9")
     implementation ("org.apache.commons:commons-collections4:4.4")
 
-    implementation ("org.springframework.boot:spring-boot-starter-web:2.5.10") // Secure and stable
+    implementation ("org.springframework.boot:spring-boot-starter-web")
 
-    // Upgrade to Log4j2 which resolves vulnerabilities found in Log4j 1.x
     implementation ("org.apache.logging.log4j:log4j-core:2.14.1")
     implementation ("org.apache.logging.log4j:log4j-api:2.14.1")
 
-    // Upgrade to latest Gson version
     implementation ("com.google.code.gson:gson:2.8.9")
-
 
     implementation ("com.google.guava:guava:18.0")
 
     implementation ("com.fasterxml.jackson.core:jackson-databind:2.8.11")
-
     implementation ("com.fasterxml.jackson.core:jackson-core:2.8.11")
-
     implementation ("com.fasterxml.jackson.core:jackson-annotations:2.8.11")
 
     implementation ("commons-net:commons-net:3.6")
 
-
     testImplementation ("org.junit.jupiter:junit-jupiter-api:5.8.1")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.8.1")
-
 }
 
 tasks.test {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,2 +1,1 @@
-rootProject.name = "BillingService"
-
+rootProject.name = "AuthenticationService"

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -17,57 +17,70 @@ import com.google.common.io.Files;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.commons.net.ftp.FTPClient;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
 
+import javax.annotation.PostConstruct;
 import java.io.File;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
+@SpringBootApplication
+@RestController
 public class Main {
     static Logger logger = Logger.getLogger(String.valueOf(Main.class));
 
     public static void main(String[] args) {
+        SpringApplication.run(Main.class, args);
+    }
+
+    @PostConstruct
+    public void init() {
         logger.info("Application started with dependencies!");
-        System.out.println("Hello, World!");
         processFileName("myFile.txt");
         useStringUtils("  test  ");
         fileUploadExample();
         FileOperations fo = new FileOperations();
         fo.fewMore();
-
         useGuava();
         useJackson();
         useCommonsNet();
+
         Transformer<String, String> transformer = new InvokerTransformer<>(
                 "toString",
                 new Class[]{},
                 new Object[]{}
         );
-        
         Map<String, String> lazyMap = LazyMap.lazyMap(new HashMap<String, String>(), transformer);
         lazyMap.put("key", "value");
+    }
 
-        try {
-            System.out.println("Server is running. Press Ctrl+C to stop.");
-            Thread.currentThread().join(); // Keeps the main thread alive
-        } catch (InterruptedException e) {
-            logger.warning("Server interrupted: " + e.getMessage());
-        }
+    @GetMapping("/health")
+    public Map<String, String> health() {
+        return Map.of("status", "UP", "service", "AuthenticationService");
+    }
+
+    @GetMapping("/")
+    public String home() {
+        return "AuthenticationService is running";
     }
 
     public void performComplexOperations() {
         Gson gson = new Gson();
-        String jsonBad = "{\"dateField\":\"invalid-date-format\"}"; // Test serialization issues
+        String jsonBad = "{\"dateField\":\"invalid-date-format\"}";
 
         try {
-            MyModel myModel = gson.fromJson(jsonBad, MyModel.class); // Considering breaking changes in handling of dates
+            MyModel myModel = gson.fromJson(jsonBad, MyModel.class);
         } catch (Exception e) {
             logger.info("Error in processing due to compatibility");
         }
 
         ConfigurationBuilder<?> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
-        builder.add(builder.newRootLogger(Level.ERROR));  // Reflect how configurations may fail across major upgrades
+        builder.add(builder.newRootLogger(Level.ERROR));
     }
 
     public static void processFileName(String name) {
@@ -82,7 +95,6 @@ public class Main {
         DiskFileItemFactory factory = new DiskFileItemFactory();
         File tempDir = new File(System.getProperty("java.io.tmpdir"));
         factory.setRepository(tempDir);
-        // We are not actually processing a request here, just instantiating
         System.out.println("File upload factory created.");
     }
 


### PR DESCRIPTION
## Problem\nNR Java agent requires an active web server to report JarOpenEvent (dependency data) for vulnerability detection. The plain `main()` app connected to NR but didn't trigger dependency reporting.\n\n## Changes\n- Added Spring Boot plugin (`org.springframework.boot` + `io.spring.dependency-management`)\n- Converted `Main.java` to `@SpringBootApplication` with `SpringApplication.run()`\n- Added `/health` and `/` endpoints\n- Moved init logic to `@PostConstruct`\n- Fixed `settings.gradle.kts` project name\n\n## Result\nSpring Boot starts embedded Tomcat, NR agent fully instruments it, and `JarOpenEvent` data flows to Vulnerability Management.