### PR TITLE
Fix Jackson version conflict with Spring Boot BOM

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,9 +46,9 @@ dependencies {
 
     implementation ("com.google.guava:guava:18.0")
 
-    implementation ("com.fasterxml.jackson.core:jackson-databind:2.8.11")
-    implementation ("com.fasterxml.jackson.core:jackson-core:2.8.11")
-    implementation ("com.fasterxml.jackson.core:jackson-annotations:2.8.11")
+    implementation ("com.fasterxml.jackson.core:jackson-databind")
+    implementation ("com.fasterxml.jackson.core:jackson-core")
+    implementation ("com.fasterxml.jackson.core:jackson-annotations")
 
     implementation ("commons-net:commons-net:3.6")
 

--- a/src/main/java/org/example/Main.java
+++ b/src/main/java/org/example/Main.java
@@ -15,7 +15,6 @@ import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFact
 
 import com.google.common.io.Files;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.commons.net.ftp.FTPClient;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -116,7 +115,7 @@ public class Main {
         try {
             Object result = mapper.readValue(jsonInput, Object.class);
             System.out.println("Jackson deserialization completed: " + result);
-        } catch (JsonProcessingException e) {
+        } catch (Exception e) {
             System.out.println("Jackson processing failed: " + e.getMessage());
         }
     }


### PR DESCRIPTION
Remove explicit Jackson 2.8.11 versions (incompatible with Spring Boot 2.5.10) and let Spring Boot BOM manage them. Fix catch block from JsonProcessingException to Exception.